### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM php:8.4-fpm-alpine
 ARG APP_ENV=prod
 ARG USER_ID=1000
 ARG GROUP_ID=1000
+ENV COMPOSER_MEMORY_LIMIT=-1
 
 # Installation des dépendances système
 RUN apk add --no-cache \


### PR DESCRIPTION
This pull request includes a small change to the `Dockerfile`. The change sets the `COMPOSER_MEMORY_LIMIT` environment variable to `-1` to remove memory limits when using Composer.

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R7): Added `ENV COMPOSER_MEMORY_LIMIT=-1` to remove Composer memory limits.Composer memory optimization in Dockerfile