### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,23 +19,16 @@ services:
       - DOMAIN_NAME=${DOMAIN_NAME}
     networks:
       - hey_voisin_network
+      - proxy  # Ajout du réseau proxy
     depends_on:
       - database
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.heyvoisin-app.rule=Host(`${DOMAIN}`)"
-      - "traefik.http.routers.heyvoisin-app.entrypoints=websecure"
-      - "traefik.http.routers.heyvoisin-app.tls.certresolver=le"
-      - "traefik.http.services.heyvoisin-app.loadbalancer.server.port=80"
 
   # Serveur web Nginx
   web:
     image: nginx:alpine
     container_name: hey_voisin_nginx
     restart: unless-stopped
-    ports:
-      - "80:80"
-      - "443:443"
+    # Suppression des ports exposés, Traefik s'en charge
     volumes:
       - ./:/var/www/symfony
       - ./docker/nginx/conf.d:/etc/nginx/conf.d
@@ -47,12 +40,13 @@ services:
       - app
     networks:
       - hey_voisin_network
+      - proxy  # Ajout du réseau proxy
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.heyvoisin-app.rule=Host(`${DOMAIN:-localhost}`)"
-      - "traefik.http.routers.heyvoisin-app.entrypoints=websecure"
-      - "traefik.http.routers.heyvoisin-app.tls.certresolver=le"
-      - "traefik.http.services.heyvoisin-app.loadbalancer.server.port=80"
+      - "traefik.http.routers.heyvoisin.rule=Host(`${DOMAIN_NAME:-localhost}`)"
+      - "traefik.http.routers.heyvoisin.entrypoints=websecure"
+      - "traefik.http.routers.heyvoisin.tls.certresolver=le"
+      - "traefik.http.services.heyvoisin.loadbalancer.server.port=80"
 
   # Base de données MariaDB/MySQL
   database:
@@ -76,3 +70,5 @@ volumes:
 networks:
   hey_voisin_network:
     driver: bridge
+  proxy:
+    external: true  # Référence au réseau externe créé pour Traefik


### PR DESCRIPTION
This pull request includes several changes to the `docker-compose.yml` file to improve network configuration and Traefik integration. The most important changes include adding a new network for the proxy, removing exposed ports for Nginx, and updating Traefik labels.

Network configuration updates:

* Added the `proxy` network to the `app` and `web` services to facilitate Traefik integration. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R22-R31) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R43-R49)
* Added an external `proxy` network reference for Traefik in the `volumes` section.

Traefik integration improvements:

* Removed exposed ports for the Nginx service as Traefik will handle them.
* Updated Traefik labels to reflect the new network configuration and domain name handling.