### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - DOMAIN_NAME=${DOMAIN_NAME}
     networks:
       - hey_voisin_network
-      - proxy  # Ajout du réseau proxy
+      - proxy  
     depends_on:
       - database
 
@@ -28,7 +28,6 @@ services:
     image: nginx:alpine
     container_name: hey_voisin_nginx
     restart: unless-stopped
-    # Suppression des ports exposés, Traefik s'en charge
     volumes:
       - ./:/var/www/symfony
       - ./docker/nginx/conf.d:/etc/nginx/conf.d
@@ -43,7 +42,7 @@ services:
       - proxy  # Ajout du réseau proxy
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.heyvoisin.rule=Host(`${DOMAIN_NAME:-localhost}`)"
+      - "traefik.http.routers.heyvoisin.rule=Host(`${DOMAIN_NAME}`)"
       - "traefik.http.routers.heyvoisin.entrypoints=websecure"
       - "traefik.http.routers.heyvoisin.tls.certresolver=le"
       - "traefik.http.services.heyvoisin.loadbalancer.server.port=80"
@@ -71,4 +70,4 @@ networks:
   hey_voisin_network:
     driver: bridge
   proxy:
-    external: true  # Référence au réseau externe créé pour Traefik
+    external: true


### PR DESCRIPTION
This pull request includes several changes to the `docker-compose.yml` file, primarily focusing on cleaning up comments and ensuring proper network configurations. The most important changes include the removal of unnecessary comments and the correction of the `DOMAIN_NAME` variable usage.

Cleanup and configuration adjustments:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L22-R22): Removed unnecessary comments regarding the proxy network and exposed ports. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L22-R22) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L31) [[3]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L74-R73)
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L46-R45): Corrected the `DOMAIN_NAME` variable usage in the Traefik router rule to ensure proper hostname resolution.