### PR TITLE
Update deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -185,7 +185,7 @@ jobs:
                   - proxy
                 labels:
                   - "traefik.enable=true"
-                  - "traefik.http.routers.heyvoisin.rule=Host(`${{DOMAIN_NAME}}`)"
+                  - "traefik.http.routers.heyvoisin.rule=Host(`${{ secrets.DOMAIN_NAME }}`)"
                   - "traefik.http.routers.heyvoisin.entrypoints=websecure"
                   - "traefik.http.routers.heyvoisin.tls=true"
                   - "traefik.http.routers.heyvoisin.tls.certresolver=le"


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/deploy.yml` file to enhance security by using a GitHub secret for the domain name in the Traefik configuration.

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L188-R188): Changed the `traefik.http.routers.heyvoisin.rule` label to use `${{ secrets.DOMAIN_NAME }}` instead of `${{DOMAIN_NAME}}` for improved security.