### PR TITLE
Update deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -185,7 +185,7 @@ jobs:
                   - proxy
                 labels:
                   - "traefik.enable=true"
-                  - "traefik.http.routers.heyvoisin.rule=Host(`${{DOMAIN_NAME}}`)"
+                  - "traefik.http.routers.heyvoisin.rule=Host(`${DOMAIN_NAME}`)"
                   - "traefik.http.routers.heyvoisin.entrypoints=websecure"
                   - "traefik.http.routers.heyvoisin.tls=true"
                   - "traefik.http.routers.heyvoisin.tls.certresolver=le"


### PR DESCRIPTION
This pull request includes a small but important change to the `.github/workflows/deploy.yml` file. The change corrects the syntax for the `DOMAIN_NAME` placeholder in the Traefik router rule.

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L188-R188): Corrected the syntax for the `DOMAIN_NAME` placeholder in the Traefik router rule to ensure proper environment variable substitution.