### PR TITLE
Update deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -103,7 +103,7 @@ jobs:
           cat > docker-compose.prod.yml << EOL
           # Contenu de votre docker-compose
           EOL
-          sed -i 's/Host()/Host(`'"${{ secrets.SUBDOMAIN }}"'.'"${{ secrets.DOMAIN }}"'`)/' docker-compose.prod.yml
+          sed -i 's/Host()/Host(`'"${{ secrets.DOMAIN }}"'`)/' docker-compose.prod.yml
 
       - name: Deploy to VPS
         uses: appleboy/ssh-action@v1
@@ -149,7 +149,7 @@ jobs:
             MAILER_DSN=${{ secrets.MAILER_DSN }}
             CORS_ALLOW_ORIGIN=${{ secrets.CORS_ALLOW_ORIGIN }}
             JWT_PASSPHRASE=${{ secrets.JWT_PASSPHRASE }}
-            DOMAIN_NAME=${{ secrets.SUBDOMAIN }}.${{ secrets.DOMAIN }}
+            DOMAIN_NAME=${{ secrets.DOMAIN }}
             EOL
             
             # Création de docker-compose.prod.yml
@@ -168,7 +168,7 @@ jobs:
                   - APP_ENV=${APP_ENV:-prod}
                   - APP_SECRET=${APP_SECRET}
                   - DATABASE_URL=${DATABASE_URL}
-                  - DOMAIN_NAME=${DOMAIN_NAME}
+                  - DOMAIN_NAME=${DOMAIN}
                 networks:
                   - hey_voisin_network
                   - proxy
@@ -190,7 +190,7 @@ jobs:
                   - proxy
                 labels:
                   - "traefik.enable=true"
-                  - "traefik.http.routers.heyvoisin.rule=Host(`${DOMAIN_NAME}`)"
+                  - "traefik.http.routers.heyvoisin.rule=Host(`${DOMAIN}`)"
                   - "traefik.http.routers.heyvoisin.entrypoints=websecure"
                   - "traefik.http.routers.heyvoisin.tls=true"
                   - "traefik.http.routers.heyvoisin.tls.certresolver=le"


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/deploy.yml` file to simplify the configuration by removing the use of the `SUBDOMAIN` secret and only using the `DOMAIN` secret. The most important changes are listed below:

Simplification of domain configuration:

* Updated the `sed` command to replace `Host()` with only the `DOMAIN` secret instead of combining `SUBDOMAIN` and `DOMAIN` (`.github/workflows/deploy.yml`, [.github/workflows/deploy.ymlL106-R106](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L106-R106)).
* Changed the `DOMAIN_NAME` environment variable to use only the `DOMAIN` secret (`.github/workflows/deploy.yml`, [.github/workflows/deploy.ymlL152-R152](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L152-R152)).
* Modified the `DOMAIN_NAME` variable in the Docker service environment section to use `DOMAIN` (`.github/workflows/deploy.yml`, [.github/workflows/deploy.ymlL171-R171](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L171-R171)).
* Updated the Traefik router rule to use the `DOMAIN` secret directly (`.github/workflows/deploy.yml`, [.github/workflows/deploy.ymlL193-R193](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L193-R193)).