### PR TITLE
fix(ssl-conflict): simplify Nginx configuration by removing unnecessa…

### DIFF
--- a/docker/nginx/conf.d/default.conf
+++ b/docker/nginx/conf.d/default.conf
@@ -1,77 +1,22 @@
 server {
     listen 80;
-    server_name hey-voisin-api.hicham-hamza.dev www.hey-voisin-api.hicham-hamza.dev;
-    return 301 https://$host$request_uri;
-}
-
-server {
-    listen 443 ssl http2;
-    server_name hey-voisin-api.hicham-hamza.dev www.hey-voisin-api.hicham-hamza.dev;
-
-    # Certificats SSL (à ajuster avec vos certificats)
-    ssl_certificate /etc/nginx/ssl/fullchain.pem;
-    ssl_certificate_key /etc/nginx/ssl/privkey.pem;
-
-    # Configuration SSL optimisée
-    ssl_protocols TLSv1.2 TLSv1.3;
-    ssl_prefer_server_ciphers on;
-    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
-    ssl_session_timeout 1d;
-    ssl_session_cache shared:SSL:10m;
-    ssl_session_tickets off;
-
-    # Taille maximale des uploads
-    client_max_body_size 20M;
-
-    # Racine du projet Symfony
     root /var/www/symfony/public;
-
-    # Fichiers d'index
     index index.php;
-
-    # Gestion des types MIME
-    include /etc/nginx/mime.types;
-    default_type application/octet-stream;
-
-    # Logs
-    access_log /var/log/nginx/symfony_access.log;
-    error_log /var/log/nginx/symfony_error.log;
-
-    # Compression GZIP
-    gzip on;
-    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
 
     location / {
         try_files $uri /index.php$is_args$args;
     }
 
-    # Mise en cache des actifs statiques
-    location ~* \.(jpg|jpeg|png|gif|ico|css|js|woff2)$ {
-        expires 30d;
-        add_header Cache-Control "public, no-transform";
-    }
-
-    # Configuration PHP-FPM
     location ~ ^/index\.php(/|$) {
         fastcgi_pass app:9000;
         fastcgi_split_path_info ^(.+\.php)(/.*)$;
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param DOCUMENT_ROOT $document_root;
-        fastcgi_buffer_size 128k;
-        fastcgi_buffers 4 256k;
-        fastcgi_busy_buffers_size 256k;
-        fastcgi_param APP_ENV prod;
         internal;
     }
 
-    # Sécurité : ne pas autoriser l'accès direct aux fichiers PHP
     location ~ \.php$ {
         return 404;
-    }
-
-    # Sécurité supplémentaire
-    location ~ /\.ht {
-        deny all;
     }
 }


### PR DESCRIPTION
This pull request includes significant changes to the `docker/nginx/conf.d/default.conf` file, primarily aimed at simplifying the NGINX server configuration by removing SSL and other settings.

Simplification of NGINX configuration:

* Removed SSL configuration, including certificate paths, SSL protocols, ciphers, and session settings.
* Removed server blocks for both port 80 and port 443, consolidating the configuration into a single server block.
* Removed various security and optimization settings, such as GZIP compression, MIME type management, and static asset caching.
* Simplified PHP-FPM configuration by removing buffer settings and environment variables.
* Removed additional security settings, such as denying access to `.ht` files and blocking direct access to PHP files.